### PR TITLE
Improve documented compatibility troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ A fan-made patch for Project IGI, currently in an early stage of development. Bu
 1. Find your IGI installation directory and backup the file 'pc\IGI.exe'.
 2. Extract the contents of the ZIP archive (IGIPatch_vx.xx_XX_NoSetup.zip) to the root directory of your game, accept when prompted to replace IGI.exe.
 
+# Modern Windows setup
+For CUE/BIN disc-image installs, mount the `.cue` file rather than an individual `.bin` file.
+
+For DirectX 7 device errors such as `DDERR_UNSUPPORTED` or `Couldn't create device`, install a DirectX wrapper such as dgVoodoo2 next to `pc\IGI.exe`. The helper script below downloads dgVoodoo2 from the official GitHub release and copies only the required local files:
+
+```powershell
+tools\Install-DgVoodoo2.ps1 -GamePcDir "C:\Games\Project IGI\pc"
+```
+
+Run the setup checker to diagnose the common documented compatibility issues:
+
+```powershell
+tools\Test-ProjectIGISetup.ps1 -GamePcDir "C:\Games\Project IGI\pc"
+```
+
 # Configuration
 Individual features of the patch can be tweaked by editing the file 'IGIPatch.ini' with a text editor (eg.: Notepad). Numeric constant '1' means true/enable, whereas '0' means false/disable.
 
@@ -27,13 +42,13 @@ Individual features of the patch can be tweaked by editing the file 'IGIPatch.in
 - Disabled the hard-coded 640x480x16 mode set for the main menu. A custom main menu resolution can be set in the INI file.
 - IGI is now DPI-Aware. Solves the issue with the size of the client window being incorrect when Windows DPI scaling is set higher than 100%.
 
-# Known issues
-1. Intro videos not playing:
-- Install/register Indeo Video 5 (IV50) codec.
-2. When playing with a resolution of 2K or above, the game falls back to 640x480:
-- The game uses DirectX7, which is hardcoded to 2048x2048 pixels. Use UCyborg's Legacy Direct3D Resolution Hack or a wrapper without that limitation (eg.: dgVoodoo2).
-3. Game crashes when loading a mission:
-- Some in-game overlays (such as Rivatuner) are known to cause crashes. Disable them before launching the game.
+# Troubleshooting
+1. Intro videos do not play:
+- The game needs the legacy Indeo Video 5 codec (`IV50`). `tools\Test-ProjectIGISetup.ps1` checks whether IV50 appears to be registered. Install/register a trusted IV50 codec only if you need the original intro videos.
+2. The game falls back to 640x480 at 2K or higher:
+- DirectX 7 is limited around 2048x2048. Use dgVoodoo2 or another wrapper without that limitation. `tools\Install-DgVoodoo2.ps1` installs the required dgVoodoo2 DirectX files locally without committing wrapper DLLs to this repository.
+3. The game crashes when loading a mission:
+- Disable overlay/hook software first, especially Rivatuner/RTSS, MSI Afterburner, Discord overlay, Steam overlay, Game Bar, and GPU capture overlays. `tools\Test-ProjectIGISetup.ps1` reports common running overlay processes.
 
 # Credits
 Special thanks to @neoxaero [(Sagatt)](https://github.com/Sagatt) for the immense help provided.

--- a/tools/Install-DgVoodoo2.ps1
+++ b/tools/Install-DgVoodoo2.ps1
@@ -1,0 +1,52 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$GamePcDir,
+
+    [string]$Version = "latest"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (!(Test-Path -LiteralPath $GamePcDir -PathType Container)) {
+    throw "Game PC directory does not exist: $GamePcDir"
+}
+
+$headers = @{ "User-Agent" = "IGIPatch-setup" }
+if ($Version -eq "latest") {
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/dege-diosg/dgVoodoo2/releases/latest" -Headers $headers
+} else {
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/dege-diosg/dgVoodoo2/releases/tags/$Version" -Headers $headers
+}
+
+$asset = $release.assets | Where-Object { $_.name -match '^dgVoodoo2_.*\.zip$' -and $_.name -notmatch '_dbg|_dev' } | Select-Object -First 1
+if ($null -eq $asset) {
+    throw "Could not find a standard dgVoodoo2 ZIP asset for $($release.tag_name)."
+}
+
+$workDir = Join-Path $env:TEMP "IGIPatch-dgVoodoo2"
+$zipPath = Join-Path $workDir $asset.name
+$extractDir = Join-Path $workDir "extract"
+
+New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+if (Test-Path -LiteralPath $extractDir) {
+    Remove-Item -LiteralPath $extractDir -Recurse -Force
+}
+
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath -Headers $headers
+Expand-Archive -LiteralPath $zipPath -DestinationPath $extractDir
+
+$required = @(
+    "MS\x86\DDraw.dll",
+    "MS\x86\D3DImm.dll",
+    "dgVoodoo.conf"
+)
+
+foreach ($relative in $required) {
+    $source = Join-Path $extractDir $relative
+    if (!(Test-Path -LiteralPath $source)) {
+        throw "dgVoodoo2 package did not contain expected file: $relative"
+    }
+    Copy-Item -LiteralPath $source -Destination (Join-Path $GamePcDir (Split-Path $relative -Leaf)) -Force
+}
+
+Write-Host "Installed dgVoodoo2 $($release.tag_name) DirectX wrapper files to $GamePcDir"

--- a/tools/Test-ProjectIGISetup.ps1
+++ b/tools/Test-ProjectIGISetup.ps1
@@ -1,0 +1,86 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$GamePcDir
+)
+
+$ErrorActionPreference = "Stop"
+
+function Add-Result {
+    param(
+        [string]$Check,
+        [ValidateSet("OK", "WARN", "FAIL")]
+        [string]$Status,
+        [string]$Detail
+    )
+
+    [pscustomobject]@{
+        Check = $Check
+        Status = $Status
+        Detail = $Detail
+    }
+}
+
+if (!(Test-Path -LiteralPath $GamePcDir -PathType Container)) {
+    Add-Result "Game directory" "FAIL" "Directory does not exist: $GamePcDir"
+    exit 1
+}
+
+$gameExe = Join-Path $GamePcDir "IGI.exe"
+if (Test-Path -LiteralPath $gameExe -PathType Leaf) {
+    Add-Result "Game executable" "OK" "Found IGI.exe"
+} else {
+    Add-Result "Game executable" "FAIL" "IGI.exe not found in $GamePcDir"
+}
+
+$ddraw = Join-Path $GamePcDir "DDraw.dll"
+$d3dimm = Join-Path $GamePcDir "D3DImm.dll"
+if ((Test-Path -LiteralPath $ddraw -PathType Leaf) -and (Test-Path -LiteralPath $d3dimm -PathType Leaf)) {
+    Add-Result "DirectX wrapper" "OK" "Found DDraw.dll and D3DImm.dll"
+} else {
+    Add-Result "DirectX wrapper" "WARN" "Missing dgVoodoo2 DirectX wrapper DLLs. Run tools\Install-DgVoodoo2.ps1 if you see DDERR_UNSUPPORTED."
+}
+
+$codecKeys = @(
+    "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Drivers32",
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\Drivers32"
+)
+$codecValues = foreach ($key in $codecKeys) {
+    if (Test-Path $key) {
+        $value = (Get-ItemProperty -Path $key -Name "vidc.iv50" -ErrorAction SilentlyContinue)."vidc.iv50"
+        if ($value) { $value }
+    }
+}
+$codecFiles = @(
+    "$env:WINDIR\System32\ir50_32.dll",
+    "$env:WINDIR\SysWOW64\ir50_32.dll"
+) | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf }
+
+if ($codecValues -or $codecFiles) {
+    Add-Result "Indeo Video 5" "OK" "IV50 codec registration or codec DLL was found."
+} else {
+    Add-Result "Indeo Video 5" "WARN" "IV50 codec was not detected. Intro videos may not play; install/register a trusted Indeo Video 5 codec if needed."
+}
+
+try {
+    Add-Type -AssemblyName System.Windows.Forms
+    $bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+    if ($bounds.Width -gt 2048 -or $bounds.Height -gt 2048) {
+        Add-Result "Display size" "WARN" "Primary display is $($bounds.Width)x$($bounds.Height). Use dgVoodoo2 or another wrapper for resolutions above DirectX 7's 2048 limit."
+    } else {
+        Add-Result "Display size" "OK" "Primary display is $($bounds.Width)x$($bounds.Height)."
+    }
+} catch {
+    Add-Result "Display size" "WARN" "Could not query primary display size: $($_.Exception.Message)"
+}
+
+$overlayNames = "RTSS", "RTSSHooksLoader32", "RTSSHooksLoader64", "MSIAfterburner", "Discord", "steam", "GameBar", "NVIDIA Share"
+$runningOverlays = Get-Process -ErrorAction SilentlyContinue | Where-Object {
+    $name = $_.ProcessName
+    $overlayNames | Where-Object { $name -like "$_*" }
+} | Select-Object -ExpandProperty ProcessName -Unique
+
+if ($runningOverlays) {
+    Add-Result "Overlay processes" "WARN" "Possible overlay/hook processes running: $($runningOverlays -join ', '). Disable them if missions crash while loading."
+} else {
+    Add-Result "Overlay processes" "OK" "No common overlay/hook processes detected."
+}


### PR DESCRIPTION
﻿## Summary

- Replace the passive README known-issues list with actionable troubleshooting steps.
- Add a setup checker for the documented video codec, high-resolution DirectX 7, and overlay-related mission-load issues.
- Add a helper to install dgVoodoo2's required DirectX wrapper files from the official GitHub release.

## Scope

This PR is intentionally limited to issues already documented in the README's known-issues section. It does not include the separate mission-unlock/decomp notes branch.

I also checked the open GitHub issues tab before opening this. The raw-input and FPS-lock requests need dedicated runtime patch work, and the license issue needs a maintainer license choice, so this PR does not claim to close those issues.

## Validation

- Parsed both PowerShell helper scripts with PowerShell's AST parser.
- Ran `tools\Test-ProjectIGISetup.ps1` against a local Project IGI install.
- Ran `git diff --check`.

## Notes

No game binaries, disc images, generated decompilation output, or third-party wrapper binaries are included.
